### PR TITLE
Fixed small bug where jesd3.py would not see that the default fuse state was in fact set.

### DIFF
--- a/util/jesd3.py
+++ b/util/jesd3.py
@@ -285,7 +285,7 @@ class JESD3Parser:
             self._parse_error("transmission checksum mismatch: expected %04X, actual %04X"
                               % (expected_checksum, actual_checksum))
 
-        if self._fuse_default is not None and self._fuse_bit_count < len(self.fuse):
+        if self._fuse_default is None and self._fuse_bit_count < len(self.fuse):
             self._parse_error("fuse default state is not specified, and only %d out of %d fuse "
                               "bits are explicitly defined"
                               % (self._fuse_bit_count, len(self.fuse)))


### PR DESCRIPTION
Hi,

When working with .JED files that do not have all of their fuses explicitly defined, a default fuse state can be defined in the .JED file. This is checked for but in the opposite sense. An extra "not" in the if statement on line 288 was removed to fix this:
<br>
<code>        if self._fuse_default is None and self._fuse_bit_count < len(self.fuse):
</code>
<br>
Previously, it had read:
<code>        if self._fuse_default is not None and self._fuse_bit_count < len(self.fuse):
</code>

Cheers